### PR TITLE
update in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yarn add express-comments-swagger
 ```
 const express = require('express');
 const app = express();
-const expressSwagger = require('express-swagger-generator')(app);
+const expressSwagger = require('express-comments-swagger')(app);
 
 let options = {
     swaggerDefinition: {


### PR DESCRIPTION
fix the name of import(require) in the usage documentation.
'express-swagger-generator' to 'express-comments-swagger'